### PR TITLE
Fix frontend to connect to localhost backend instead of deployed version

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,1 @@
-VITE_BACKEND_URL=https://app-oozjnrse.fly.dev
+VITE_BACKEND_URL=http://localhost:8000


### PR DESCRIPTION
- Updated VITE_BACKEND_URL from https://app-oozjnrse.fly.dev to http://localhost:8000
- This resolves WebSocket connection failures when running locally
- Frontend will now properly connect to local MediaPipe backend for pose detection